### PR TITLE
Add the repository field to Cargo.toml

### DIFF
--- a/crates/smve_macros/Cargo.toml
+++ b/crates/smve_macros/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.1"
 edition = "2021"
 description = "Macro implementations for smve"
 license = "MIT OR Apache-2.0"
+repository = "https://github.com/smve-rs/smve"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.